### PR TITLE
feat: ✨ update station data to N02-2025 (令和7年度版)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,19 +155,19 @@ Environment variables (`VITE_SUPABASE_URL`, `VITE_SUPABASE_PUBLISHABLE_KEY`) mus
 
 ## Station Data Import
 
-Import railway station data from [National Land Numerical Information (国土数値情報)](https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-N02-2024.html) into Supabase.
+Import railway station data from [National Land Numerical Information (国土数値情報)](https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-N02-2025.html) into Supabase.
 The dataset is governed by its own terms of use — see [Third-party data](#third-party-data) for details.
 
 ### Setup
 
-1. Download the GeoJSON data from the link above (`N02-24_GML.zip`)
+1. Download the GeoJSON data from the link above (`N02-25_GML.zip`)
 2. Extract the ZIP and place it under `data/`:
 
    ```plain
    data/
-     N02-24_GML/
+     N02-25_GML/
        UTF-8/
-         N02-24_Station.geojson
+         N02-25_Station.geojson
    ```
 
 3. Ensure `SUPABASE_SECRET_KEY` is set in `.env.local` (create a secret key in Supabase Dashboard -> Settings -> API)
@@ -176,10 +176,10 @@ The dataset is governed by its own terms of use — see [Third-party data](#thir
 
 ```bash
 # Dry run (parse and validate without inserting)
-npm run import:stations -- data/N02-24_GML/UTF-8/N02-24_Station.geojson --dry-run
+npm run import:stations -- data/N02-25_GML/UTF-8/N02-25_Station.geojson --dry-run
 
 # Import into Supabase
-npm run import:stations -- data/N02-24_GML/UTF-8/N02-24_Station.geojson
+npm run import:stations -- data/N02-25_GML/UTF-8/N02-25_Station.geojson
 ```
 
 The script is idempotent: re-running it will skip stations that already exist in the database.
@@ -194,5 +194,5 @@ This project's source code is licensed under the [MIT License](LICENSE).
 
 #### Third-party data
 
-Railway station data is derived from [National Land Numerical Information (国土数値情報)](https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-N02-2024.html) provided by the Ministry of Land, Infrastructure, Transport and Tourism (MLIT) of Japan, and its use is governed by the [国土数値情報 利用約款](https://nlftp.mlit.go.jp/ksj/other/agreement.html).
+Railway station data is derived from [National Land Numerical Information (国土数値情報)](https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-N02-2025.html) provided by the Ministry of Land, Infrastructure, Transport and Tourism (MLIT) of Japan, and its use is governed by the [国土数値情報 利用約款](https://nlftp.mlit.go.jp/ksj/other/agreement.html).
 Attribution is required by that agreement; the original source is credited above.

--- a/index.html
+++ b/index.html
@@ -21,30 +21,6 @@
   </head>
   <body class="min-h-screen lg:h-screen flex flex-col">
     <div id="root" class="flex-1 min-h-0"></div>
-    <footer class="bg-base-100 text-base-content text-sm py-2 px-4 border-t border-base-300 flex items-center justify-center gap-4">
-      <span class="text-base-content/60">
-        © 2024
-        <a
-          href="https://github.com/shin-sforzando"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="link link-hover"
-        >shin-sforzando</a>
-      </span>
-      <a
-        href="https://github.com/shin-sforzando/rendez-vous"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="link link-hover inline-flex items-center gap-1"
-        aria-label="GitHub repository"
-      >
-        <svg viewBox="0 0 24 24" class="h-4 w-4 fill-current" role="img">
-          <title>GitHub</title>
-          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-        </svg>
-        GitHub
-      </a>
-    </footer>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -108,7 +108,7 @@ describe('App', () => {
 
     it('should show empty state in ResultCard when no locations', () => {
       render(<App />)
-      expect(screen.getByText('登録済み出発地（0）')).toBeInTheDocument()
+      expect(screen.getByText('出発地（0）')).toBeInTheDocument()
     })
 
     it('should render theme toggle', () => {
@@ -124,7 +124,7 @@ describe('App', () => {
 
       const resultCard = screen.getByTestId('result-card')
       expect(within(resultCard).getByText('東京駅')).toBeInTheDocument()
-      expect(screen.getByText('登録済み出発地（1）')).toBeInTheDocument()
+      expect(screen.getByText('出発地（1）')).toBeInTheDocument()
     })
 
     it('should add a location via station search', () => {
@@ -154,8 +154,8 @@ describe('App', () => {
       render(<App />)
       addLocationViaForm('東京駅', '35.6812', '139.7671')
 
-      expect(screen.getByText('登録済み出発地（1）')).toBeInTheDocument()
-      expect(screen.queryByText('計算結果')).not.toBeInTheDocument()
+      expect(screen.getByText('出発地（1）')).toBeInTheDocument()
+      expect(screen.queryByText('結果')).not.toBeInTheDocument()
     })
   })
 
@@ -165,7 +165,7 @@ describe('App', () => {
       addLocationViaForm('東京駅', '35.6812', '139.7671')
       addLocationViaForm('新宿駅', '35.6896', '139.7006')
 
-      expect(screen.getByText('計算結果')).toBeInTheDocument()
+      expect(screen.getByText('結果')).toBeInTheDocument()
     })
 
     it('should display centroid and geometric median on map', () => {
@@ -207,12 +207,12 @@ describe('App', () => {
       addLocationViaForm('東京駅', '35.6812', '139.7671')
       addLocationViaForm('新宿駅', '35.6896', '139.7006')
 
-      expect(screen.getByText('計算結果')).toBeInTheDocument()
+      expect(screen.getByText('結果')).toBeInTheDocument()
 
       fireEvent.click(screen.getByLabelText('東京駅を削除'))
 
-      expect(screen.queryByText('計算結果')).not.toBeInTheDocument()
-      expect(screen.getByText('登録済み出発地（1）')).toBeInTheDocument()
+      expect(screen.queryByText('結果')).not.toBeInTheDocument()
+      expect(screen.getByText('出発地（1）')).toBeInTheDocument()
     })
   })
 
@@ -257,7 +257,7 @@ describe('App', () => {
       const resultCard = screen.getByTestId('result-card')
       expect(within(resultCard).getByText('渋谷')).toBeInTheDocument()
       expect(within(resultCard).getByText('横浜駅')).toBeInTheDocument()
-      expect(screen.getByText('計算結果')).toBeInTheDocument()
+      expect(screen.getByText('結果')).toBeInTheDocument()
     })
   })
 
@@ -325,7 +325,7 @@ describe('App', () => {
       render(<App />)
       // Data source credit is displayed in the map component
       expect(screen.getByText(/国土交通省 国土数値情報/)).toBeInTheDocument()
-      expect(screen.getByText(/2025年6月/)).toBeInTheDocument()
+      expect(screen.getByText(/2026年4月/)).toBeInTheDocument()
     })
 
     it('should render data source link with correct href', () => {
@@ -333,8 +333,35 @@ describe('App', () => {
       const dataLink = screen.getByRole('link', { name: /国土交通省 国土数値情報/ })
       expect(dataLink).toHaveAttribute(
         'href',
-        'https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-N02-2024.html'
+        'https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-N02-2025.html'
       )
+    })
+  })
+
+  describe('footer placement', () => {
+    it('should render two footer instances with mutually exclusive responsive classes', () => {
+      const { container } = render(<App />)
+      const footers = container.querySelectorAll('footer')
+      expect(footers).toHaveLength(2)
+
+      // Desktop footer (visible at lg+): "hidden lg:flex", placed inside the aside
+      const desktopFooter = Array.from(footers).find((f) => f.className.includes('lg:flex'))
+      // Mobile footer (visible below lg): "flex lg:hidden", placed at site bottom
+      const mobileFooter = Array.from(footers).find((f) => f.className.includes('lg:hidden'))
+
+      expect(desktopFooter).toBeDefined()
+      expect(desktopFooter?.className).toContain('hidden')
+      expect(mobileFooter).toBeDefined()
+      expect(mobileFooter?.className).toContain('flex')
+    })
+
+    it('should place the desktop footer inside the left aside', () => {
+      const { container } = render(<App />)
+      const aside = container.querySelector('aside')
+      expect(aside).not.toBeNull()
+      const asideFooter = aside?.querySelector('footer')
+      expect(asideFooter).not.toBeNull()
+      expect(asideFooter?.className).toContain('lg:flex')
     })
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import Footer from '@/components/Footer'
 import LocationForm from '@/components/LocationForm'
 import MapView from '@/components/Map'
 import ResultCard from '@/components/ResultCard'
@@ -127,21 +128,24 @@ function App() {
       </header>
 
       <main className="flex-1 flex flex-col lg:flex-row gap-4 p-4 min-h-0">
-        {/* Left column: input form + result card (scrollable on desktop) */}
-        <aside className="w-full lg:w-md shrink-0 flex flex-col gap-4 lg:overflow-y-auto overflow-x-hidden">
-          <LocationForm onAdd={handleAddLocation} disabled={isMaxReached} />
-          <ResultCard
-            locations={locations}
-            result={result}
-            onRemove={handleRemoveLocation}
-            centroidNearbyStations={centroidNearby.stations}
-            medianNearbyStations={medianNearby.stations}
-            suggestedStation={suggestedStation}
-            isLoadingNearbyStations={centroidNearby.isLoading || medianNearby.isLoading}
-            onCopyUrl={handleCopyUrl}
-            isCopied={isCopied}
-            onFocusMap={handleFocusMap}
-          />
+        {/* Left column: input form + result card (scrollable on desktop) + desktop-only footer pinned to bottom */}
+        <aside className="w-full lg:w-md shrink-0 flex flex-col lg:overflow-hidden">
+          <div className="flex flex-col gap-4 lg:flex-1 lg:overflow-y-auto overflow-x-hidden">
+            <LocationForm onAdd={handleAddLocation} disabled={isMaxReached} />
+            <ResultCard
+              locations={locations}
+              result={result}
+              onRemove={handleRemoveLocation}
+              centroidNearbyStations={centroidNearby.stations}
+              medianNearbyStations={medianNearby.stations}
+              suggestedStation={suggestedStation}
+              isLoadingNearbyStations={centroidNearby.isLoading || medianNearby.isLoading}
+              onCopyUrl={handleCopyUrl}
+              isCopied={isCopied}
+              onFocusMap={handleFocusMap}
+            />
+          </div>
+          <Footer className="hidden lg:flex mt-4" />
         </aside>
 
         {/* Right column: map (fills remaining space) */}
@@ -157,6 +161,9 @@ function App() {
           />
         </div>
       </main>
+
+      {/* Mobile-only footer at site bottom (desktop footer is inside the left aside) */}
+      <Footer className="flex lg:hidden" />
     </div>
   )
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,39 @@
+type FooterProps = {
+  className?: string
+}
+
+/** Site footer: copyright + GitHub repository link. */
+function Footer({ className = '' }: FooterProps) {
+  return (
+    <footer
+      className={`text-base-content text-sm py-2 px-4 items-center justify-center gap-4 ${className}`}
+    >
+      <span className="text-base-content/60">
+        © 2024{' '}
+        <a
+          href="https://github.com/shin-sforzando"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="link link-hover"
+        >
+          shin-sforzando
+        </a>
+      </span>
+      <a
+        href="https://github.com/shin-sforzando/rendez-vous"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="link link-hover inline-flex items-center gap-1"
+        aria-label="GitHub repository"
+      >
+        <svg viewBox="0 0 24 24" className="h-4 w-4 fill-current" role="img">
+          <title>GitHub</title>
+          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+        </svg>
+        GitHub
+      </a>
+    </footer>
+  )
+}
+
+export default Footer

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -426,14 +426,14 @@ function MapView({
       <div className="absolute bottom-6 right-2 z-[1000] text-xs text-base-content/70 bg-base-100/80 px-2 py-0.5 rounded">
         駅データ:{' '}
         <a
-          href="https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-N02-2024.html"
+          href="https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-N02-2025.html"
           target="_blank"
           rel="noopener noreferrer"
           className="underline hover:text-primary"
         >
           国土交通省 国土数値情報
         </a>{' '}
-        (2025年6月)
+        (2026年4月)
       </div>
     </div>
   )

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -188,7 +188,7 @@ function ResultCard({
     <div data-testid="result-card" className="card bg-base-100 shadow-md">
       <div className="card-body">
         <h2 className="card-title text-lg">
-          {result ? '計算結果' : `登録済み出発地（${locations.length}）`}
+          {result ? '結果' : `出発地（${locations.length}）`}
         </h2>
 
         {/* Empty state */}

--- a/src/components/ResultCard.tsx
+++ b/src/components/ResultCard.tsx
@@ -187,9 +187,7 @@ function ResultCard({
   return (
     <div data-testid="result-card" className="card bg-base-100 shadow-md">
       <div className="card-body">
-        <h2 className="card-title text-lg">
-          {result ? '結果' : `出発地（${locations.length}）`}
-        </h2>
+        <h2 className="card-title text-lg">{result ? '結果' : `出発地（${locations.length}）`}</h2>
 
         {/* Empty state */}
         {locations.length === 0 && (

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Footer from '@/components/Footer'
+
+describe('Footer', () => {
+  it('renders copyright text with author name', () => {
+    render(<Footer />)
+    expect(screen.getByText(/© 2024/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'shin-sforzando' })).toBeInTheDocument()
+  })
+
+  it('renders author profile link with correct href', () => {
+    render(<Footer />)
+    const link = screen.getByRole('link', { name: 'shin-sforzando' })
+    expect(link).toHaveAttribute('href', 'https://github.com/shin-sforzando')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders GitHub repository link with correct href', () => {
+    render(<Footer />)
+    const link = screen.getByRole('link', { name: /GitHub repository/ })
+    expect(link).toHaveAttribute('href', 'https://github.com/shin-sforzando/rendez-vous')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('merges custom className onto the root element', () => {
+    const { container } = render(<Footer className="hidden lg:flex" />)
+    const footer = container.querySelector('footer')
+    expect(footer).not.toBeNull()
+    expect(footer?.className).toContain('hidden')
+    expect(footer?.className).toContain('lg:flex')
+  })
+})

--- a/src/components/__tests__/ResultCard.test.tsx
+++ b/src/components/__tests__/ResultCard.test.tsx
@@ -35,14 +35,14 @@ describe('ResultCard', () => {
 
     it('should show location count in heading', () => {
       render(<ResultCard locations={[]} result={null} />)
-      expect(screen.getByText('登録済み出発地（0）')).toBeInTheDocument()
+      expect(screen.getByText('出発地（0）')).toBeInTheDocument()
     })
   })
 
   describe('with locations but no result (< 2 locations)', () => {
     it('should show location count heading', () => {
       render(<ResultCard locations={[LOCATIONS[0]]} result={null} />)
-      expect(screen.getByText('登録済み出発地（1）')).toBeInTheDocument()
+      expect(screen.getByText('出発地（1）')).toBeInTheDocument()
     })
 
     it('should display the location name', () => {
@@ -59,7 +59,7 @@ describe('ResultCard', () => {
   describe('with result (>= 2 locations)', () => {
     it('should show calculation result heading', () => {
       render(<ResultCard locations={LOCATIONS} result={MOCK_RESULT} />)
-      expect(screen.getByText('計算結果')).toBeInTheDocument()
+      expect(screen.getByText('結果')).toBeInTheDocument()
     })
 
     it('should display centroid card with label and coordinates', () => {


### PR DESCRIPTION
## 概要

Closes #47

国土交通省 国土数値情報の駅データを **令和7年度版 (N02-2025、2026年4月公開)** に差し替え。新規開業駅・廃駅・路線改称を反映するための年次更新。

データ実体は `.gitignore` 対象なのでリポジトリ管理外。本 PR の差分はバージョン参照と関連 UI リファクタのみ。

## 主な変更

### 1. 駅データ N02-25 更新（Issue #47 本体）

- `README.md`: Station Data Import セクションの URL・ZIP 名・パス例・コマンド例を `N02-24`/`KsjTmplt-N02-2024` から `N02-25`/`KsjTmplt-N02-2025` へ
- `src/components/Map.tsx`: 地図右下のデータソース クレジット (URL + 表示日付 \`(2025年6月)\` → \`(2026年4月)\`)
- `src/App.test.tsx`: 上記に対応するテスト期待値の更新

\`scripts/import-stations.ts\` および \`stations\` テーブルスキーマは年度非依存（CLI 引数で GeoJSON パス指定 / カラム不変）のためコード変更不要。

### 2. Footer のコンポーネント化＋レスポンシブ配置

- 新規 `src/components/Footer.tsx` + テスト
- `index.html` 末尾のインラインフッターを削除
- `src/App.tsx`: デスクトップ (lg+) では左 aside の最下部、モバイルではサイト最下部に配置（`hidden lg:flex` / `flex lg:hidden` で排他制御）

### 3. ResultCard のラベル簡素化

- `登録済み出発地（N）` → `出発地（N）`
- `計算結果` → `結果`
- 対応テスト更新

## 投入結果（Supabase）

\`\`\`
TRUNCATE stations RESTART IDENTITY
→ npm run import:stations -- data/N02-25_GML/UTF-8/N02-25_Station.geojson
→ 10,134 件 投入
\`\`\`

参考: N02-24 は約 10,200 件規模だったため、新規開業 / 廃駅統廃合の差し引きとして妥当な変動。

## 動作確認

### 自動テスト

- [x] \`npm run check\`（biome）パス
- [x] \`npm run test\`（vitest 全件パス）

### 差分整合性検証

- [x] \`rg -i 'N02-?24|N02-2024|2025年6月'\` ヒット 0（受け入れ条件）

### ブラウザでの動作確認（広島駅周辺で双方向検証）

- [x] **新規駅 (松川町、2025-08-03 開業)** を駅名検索 → ヒットして出発地に追加できる（N02-25 反映の証拠：N02-24 には存在しない駅）
- [x] **廃駅 (猿猴橋町、2025-08-03 廃止)** を駅名検索 → ヒット 0（廃駅処理が正しく行われた証拠）
- [x] 地図右下のクレジットが「駅データ: 国土交通省 国土数値情報 (2026年4月)」表示、リンク先が \`KsjTmplt-N02-2025.html\`
- [x] 出発地計算 → 最寄り駅サジェストが新データで動作

なお「的場町」「段原一丁目」が残存しているが、これらは 2025-08-03 に **休止** (廃止ではない、来春の環状線開業で復帰予定) となった駅であり、国土数値情報 N02 の仕様上 休止駅も収録されるため正常。

## 詳細プラン

`.claude/plans/issue-47-ancient-cosmos.md`